### PR TITLE
Temp Fix to Force Rerender of Adobe PDF view

### DIFF
--- a/src/containers/case/case.jsx
+++ b/src/containers/case/case.jsx
@@ -93,9 +93,9 @@ const CaseContainer = (props) => {
                                         if(caseByCaseCited.caseCitations.length === 0) return undefined
                                         return (
                                             <li key={idx}>
-                                                <Link to={`/case/${caseByCaseCited.caseCitations[0].id}`}>
+                                                <a href={`/case/${caseByCaseCited.caseCitations[0].id}`}>
                                                     {caseByCaseCited.caseName}
-                                                </Link>
+                                                </a>
                                             </li>
                                         )
                                     })
@@ -117,9 +117,9 @@ const CaseContainer = (props) => {
                                         currentCase.casesCitedsByCaseCited.map(({caseByCaseOrigin}, idx) => {
                                             return (
                                                 <li key={idx}>
-                                                    <Link to={`/case/${caseByCaseOrigin.caseCitations[0].id}`}>
+                                                    <a href={`/case/${caseByCaseOrigin.caseCitations[0]?.id}`}>
                                                         {caseByCaseOrigin.caseName}
-                                                    </Link>
+                                                    </a>
                                                 </li>
                                             )
                                         })


### PR DESCRIPTION
Temporary Solution. 

Just resolving this for now and then will dig into the SDK this evening to try make a more proper method for this. (The PDF view state strict mode prevents changing the address of the PDF being rerendered. Currently the only method around this is to destroy the current item from the document and then re-create it - this works but is not ideal, I'll get a better look at it this evening..)