### PR TITLE
Completed issue-33: add directors cards to Our Mission page

### DIFF
--- a/content/mission/mission.json
+++ b/content/mission/mission.json
@@ -64,6 +64,21 @@
           "title": "You can use our search for any purpose including commercial purposes."
         }
       ]
+    },
+    {
+      "title": "Directors",
+      "type": "directors",
+      "content": [
+        {
+          "name": "Andrew Easterbrook",
+          "title": "CEO",
+          "content_html": "Andrew is a lawyer, and has worked in technology law, civil litigation and family law since 2009. He has been a Member of the Auckland District Law Society Technology & Law Committee since 2012, and is experienced in web and software development. Andrew went to university at Victoria, Wellington, and now lives in Whangarei."        },
+        {
+          "name": "William Parry",
+          "title": "CTO",
+          "content_html": "William brings 15 years of tech experience across enterprise, advertising and small businesses including 8 years working with open data in projects and hackathons. He has run community coding classes and is passionate about empowering disadvantaged people with technology. William went to university at Victoria, Wellington, and now lives in Sydney."
+        }
+      ]
     }
   ],
   "title": "Our Mission"

--- a/src/containers/our-mission/our-mission.jsx
+++ b/src/containers/our-mission/our-mission.jsx
@@ -15,45 +15,40 @@ export const OurMissionContainer = ({title, modules}) => {
                 <div className="body-wrap content-page right-on-top">
                     <div className="body-left">
                         {
-                            modules.map(({ title, content }, idx) => (
-                                <article id={toSlug(title)} className="content-section" key={idx}>
-                                    <h2 className="body-title">{title}</h2>
-                                    {
-                                        content.map(({ content_html }, idx) => (
-                                            <p key={idx} dangerouslySetInnerHTML={{ __html: sanitizeHtml(content_html) }} />
-                                        ))
-                                    }
-                                </article>
-                            ))
-                        }
+                            modules.map(({ title, content }, idx) => {
+                                if (title === "Directors") {
+                                    return (
+                                        <div id="directors" className="content-section" key={title}>
+                                            <h2 className="body-title">Directors</h2>
+                                            <div className="directors-segments">
+                                                {
+                                                    content.map(({ content_html, name, title: roleTitle }, idx) => {
+                                                        return (
+                                                            <div key={idx}>
+                                                                <img src={(name === "Andrew Easterbrook") ? AndrewImage : WillImage} alt={name} />
+                                                                <h3>{name}, {roleTitle}</h3>
+                                                                <p dangerouslySetInnerHTML={{ __html: sanitizeHtml(content_html) }} />
+                                                            </div>
+                                                        )
+                                                    })
+                                                }
+                                            </div>
+                                        </div>
+                                    )
+                                }
 
-                        <div id="directors" className="content-section">
-                            <h2 className="body-title">Directors</h2>
-                            <div className="directors-segments">
-                                <div>
-                                    <img src={AndrewImage} alt="Andrew Easterbrook" />
-                                    <h3>Andrew Easterbrook, CEO</h3>
-                                    <p>
-                                        Andrew is a lawyer, and has worked in technology law, civil litigation and
-                                        family law since 2009. He has been a Member of the Auckland District Law Society
-                                        Technology & Law Committee since 2012, and is experienced in web and software
-                                        development. Andrew went to university at Victoria, Wellington, and now lives in
-                                        Whangarei.
-                                </p>
-                                </div>
-                                <div>
-                                    <img src={WillImage} alt="William Parry" />
-                                    <h3>William Parry, CTO</h3>
-                                    <p>
-                                        William brings 15 years of tech experience across enterprise, advertising and
-                                        small businesses including 8 years working with open data in projects and
-                                        hackathons. He has run community coding classes and is passionate about
-                                        empowering disadvantaged people with technology. William went to university at
-                                        Victoria, Wellington, and now lives in Sydney.
-                                </p>
-                                </div>
-                            </div>
-                        </div>
+                                return (
+                                    <article id={toSlug(title)} className="content-section" key={idx}>
+                                        <h2 className="body-title">{title}</h2>
+                                        {
+                                            content.map(({ content_html }, idx) => (
+                                                <p key={idx} dangerouslySetInnerHTML={{ __html: sanitizeHtml(content_html) }} />
+                                            ))
+                                        }
+                                    </article>
+                                )
+                                })
+                        }
                     </div>
 
                     <SideNav heading="On this page" items={modules.map(({title}) => ({ text: title, address: `#${title}`}))}/>

--- a/src/pages/our-mission.jsx
+++ b/src/pages/our-mission.jsx
@@ -5,7 +5,7 @@ import OurMissionContainer from "@/containers/our-mission/our-mission"
 
 const OurMission = ({data}) => {
     const pageContext = data.allMissionJson.nodes[0]
-    
+
     return (
         <>
             <SEO
@@ -31,6 +31,7 @@ export const query = graphql`
                 content {
                   content_html
                   title
+                  name
                 }
               }
             }


### PR DESCRIPTION
# issue-33 pull request notes

## containers/ourmission/our-mission.jsx -> OurMissionContainer component
- Uses an if statement to distinguish director module from text modules. Also assumes the directors module data in mission.json is always last in the modules array 
- directors title attribute aliased as roleTitle to avoid confusion

## pages/our-mission.jsx -> graphql query
- Added ‘name’ attribute for directors

## mission.json
- Added directors module
- Content ‘title’ attribute recycled as persons role in the organisation 
