### PR TITLE
added scroll bar to case-information sidebar issue-116

### DIFF
--- a/src/components/side-nav/side-nav.css
+++ b/src/components/side-nav/side-nav.css
@@ -8,6 +8,10 @@
 	.on-this-page {
 		text-align: center;
 	}
+	#case-information {
+		max-height: 80vh;
+		overflow-y: auto;
+	}
 }
 
 @media only screen and (min-width: 960px) {


### PR DESCRIPTION
### Notes

- The CSS has been applied to case-information id (with a minimum page width of 1200px), so that the scroll bar will only appear on case pdf pages.
- case-information sidebar is set to 80vh. This felt like a comfortable size, however please let me know if you'd prefer a larger height i.e. full page. 

### Testing
The CSS has been tested on latest versions of: Firefox, Chrome, Edge, Brave. However, it **has not** been tested on Safari. 